### PR TITLE
feat(workmux): open sidebar automatically on session creation

### DIFF
--- a/dot_config/workmux/config.yaml
+++ b/dot_config/workmux/config.yaml
@@ -5,6 +5,7 @@ merge_strategy: rebase
 
 post_create:
   - workmux setup
+  - workmux sidebar
 
 panes:
   - command: <agent>


### PR DESCRIPTION
## Summary

- Adds `workmux sidebar` to the `post_create` hook so the sidebar opens automatically when a new workmux session is created.

## Test plan

- [ ] Run `workmux add <branch>` and verify the sidebar opens automatically
- [ ] Verify `Prefix+S` still toggles the sidebar manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)