### PR TITLE
feat(shell): install fish and set as default shell

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // \"\"' | grep -qE 'README\\.md|cheatsheet\\.md' || printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"REMINDER (CLAUDE.md): if this edit added a tool, changed install steps, or modified keybindings, update README.md and dot_config/nvim/cheatsheet.md in this same response.\"}}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Personal dev environment config managed with [chezmoi](https://chezmoi.io). Buil
 | [lazydocker](https://github.com/jesseduffield/lazydocker) | Docker TUI, opens as a float in neovim |
 | [yazi](https://github.com/sxyazi/yazi) | File manager TUI |
 | [fzf](https://github.com/junegunn/fzf) | Fuzzy finder — used by tmux-sessionizer |
+| [fish](https://fishshell.com) | Default shell — autocompletion, syntax highlighting |
 
 ### Neovim extras (LazyVim)
 

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -5,7 +5,7 @@ set -e
 if command -v pacman &>/dev/null; then
     # ── CachyOS / Arch ────────────────────────────────────────────────────────
     sudo pacman -Syu --noconfirm
-    sudo pacman -S --noconfirm tmux neovim fzf lazygit yazi git curl glow
+    sudo pacman -S --noconfirm tmux neovim fzf lazygit yazi git curl glow fish
 
     # yay (AUR helper)
     if ! command -v yay &>/dev/null; then
@@ -18,7 +18,7 @@ if command -v pacman &>/dev/null; then
 elif command -v apt-get &>/dev/null; then
     # ── Ubuntu ────────────────────────────────────────────────────────────────
     sudo apt-get update
-    sudo apt-get install -y tmux fzf git curl build-essential glow
+    sudo apt-get install -y tmux fzf git curl build-essential glow fish
 
     # Neovim (binary, apt version is too old)
     NVIM_VERSION=$(curl -s https://api.github.com/repos/neovim/neovim/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
@@ -45,6 +45,13 @@ else
 fi
 
 # ── Commun ────────────────────────────────────────────────────────────────────
+# fish comme shell par défaut
+if ! grep -q "$(which fish)" /etc/shells; then
+    which fish | sudo tee -a /etc/shells
+fi
+chsh -s "$(which fish)"
+
+
 # workmux
 curl -fsSL https://raw.githubusercontent.com/raine/workmux/main/scripts/install.sh | bash
 


### PR DESCRIPTION
## Summary

- Add `fish` to install script for Arch (`pacman`) and Ubuntu (`apt`)
- Register fish in `/etc/shells` and run `chsh` to make it the default login shell
- Add `PostToolUse` hook in `.claude/settings.json` to remind Claude to update `README.md` and `cheatsheet.md` after file edits

## Test plan

- [ ] Run `chezmoi apply` on a fresh Arch machine and verify fish is installed and default
- [ ] Run `chezmoi apply` on a fresh Ubuntu machine and verify fish is installed and default
- [ ] Open Claude Code and edit a file — verify the doc reminder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)